### PR TITLE
Add support to Docker and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:alpine
+
+WORKDIR /usr/app
+
+COPY ./ ./
+RUN sed -i s/siteproxy.netptop.workers.dev/$SERVERNAME/g config.js
+RUN npm install
+
+EXPOSE 8011
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+version: "2"
+services:
+  nginx-proxy:
+    image: nginxproxy/nginx-proxy
+    container_name: nginx-proxy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./certs:/etc/nginx/certs:ro
+      - /etc/nginx/vhost.d
+      - /usr/share/nginx/html
+    restart: always
+    networks:
+      - shared
+
+  letsencrypt:
+    image: nginxproxy/acme-companion
+    container_name: letsencrypt
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./certs:/etc/nginx/certs:rw
+    volumes_from:
+      - nginx-proxy
+    restart: always
+    networks:
+      - shared
+  
+  siteproxy:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment: 
+      - VIRTUAL_HOST=site.exmple.com # Replace with your domain
+      - VIRTUAL_PORT=8011 # siteproxy's port
+      - LETSENCRYPT_HOST=site.example.com # If you don't want to set SSL certificate, you can comment out this and next line
+      - LETSENCRYPT_EMAIL=mail@example.com
+      - SERVERNAME=site.example.com # Replace with your domain. This ENV set arg for config.js
+      - VIRTUAL_NETWORK=site-proxy
+    networks:
+      - shared
+      
+networks:
+  shared:
+    external: 
+      name: site-proxy


### PR DESCRIPTION
### 概要
- Dockerサポートの為のDockerfileとdocker-compose.ymlの追加
- 動作未確認・修正必要の可能性あり
### 詳細
Dockerを使用してより簡単なビルドが可能になります
- [nginx-proxy](https://github.com/nginx-proxy/nginx-proxy)を使用してリバースプロキシの設定を行えます
- [acme-companion](https://github.com/nginx-proxy/acme-companion)を使用してLet'SEncryptによるSSL証明書発行を行えます
- docker-compose.ymlのenvironmentセクションのみの変更で、独自ドメインの設定が可能になります
### 実行方法(Linuxの例)
1. リポジトリをクローンします
`git clone https://github.com/herokuhabataku/siteproxy-.git siteproxy`
2. ディレクトリに移動します
`cd siteproxy`
3. docker-compose.ymlファイルを編集します
(例)site.example.comというサイトで構築する場合
35行目〜40行目:
```
      - VIRTUAL_HOST=site.exmple.com # ドメイン名
      - VIRTUAL_PORT=8011 # siteproxyの指定ポート
      - LETSENCRYPT_HOST=site.example.com # SSL証明書不要の場合はコメントアウト
      - LETSENCRYPT_EMAIL=mail@example.com #自分のメアド
      - SERVERNAME=site.example.com # ドメイン名、config.jsで使用
      - VIRTUAL_NETWORK=site-proxy
```
4. 構築します
`docker-compose up -d`